### PR TITLE
IDNCLOUD-28: SSO fails in tenant mode.

### DIFF
--- a/components/org.wso2.carbon.identity.sso.saml.cloud/src/main/java/org/wso2/carbon/identity/sso/saml/cloud/builders/SignKeyDataHolder.java
+++ b/components/org.wso2.carbon.identity.sso.saml.cloud/src/main/java/org/wso2/carbon/identity/sso/saml/cloud/builders/SignKeyDataHolder.java
@@ -69,7 +69,7 @@ public class SignKeyDataHolder implements X509Credential {
         try {
 
             userTenantDomain = SAMLSSOUtil.getUserTenantDomain();
-            spTenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+            spTenantDomain = SAMLSSOUtil.getTenantDomainFromThreadLocal();
 
             if (userTenantDomain == null) {
                 // all local authenticator must set the value of userTenantDomain.
@@ -91,7 +91,7 @@ public class SignKeyDataHolder implements X509Credential {
                 tenantID = SAMLSSOUtil.getRealmService().getTenantManager().getTenantId(tenantDomain);
             } else {
                 tenantDomain = spTenantDomain;
-                tenantID = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId();
+                tenantID = SAMLSSOUtil.getRealmService().getTenantManager().getTenantId(tenantDomain);
             }
 
             IdentityTenantUtil.initializeRegistry(tenantID, tenantDomain);

--- a/components/org.wso2.carbon.identity.sso.saml.cloud/src/main/java/org/wso2/carbon/identity/sso/saml/cloud/handler/auth/SPInitAuthHandler.java
+++ b/components/org.wso2.carbon.identity.sso.saml.cloud/src/main/java/org/wso2/carbon/identity/sso/saml/cloud/handler/auth/SPInitAuthHandler.java
@@ -111,6 +111,7 @@ public class SPInitAuthHandler extends AuthHandler {
             SAMLSSOUtil.setIsSaaSApplication(authnResult.isSaaSApp());
             try {
                 SAMLSSOUtil.setUserTenantDomain(authnResult.getSubject().getTenantDomain());
+                SAMLSSOUtil.setTenantDomainInThreadLocal(messageContext.getTenantDomain());
             } catch (UserStoreException e) {
                 builder = new SAMLErrorResponse.SAMLErrorResponseBuilder(messageContext);
                 return builder;

--- a/components/org.wso2.carbon.identity.sso.saml.cloud/src/main/java/org/wso2/carbon/identity/sso/saml/cloud/processor/AuthnRequestProcessor.java
+++ b/components/org.wso2.carbon.identity.sso.saml.cloud/src/main/java/org/wso2/carbon/identity/sso/saml/cloud/processor/AuthnRequestProcessor.java
@@ -72,6 +72,7 @@ public abstract class AuthnRequestProcessor extends IdentityProcessor {
                 String.valueOf(context.getParameter(InboundConstants.PassiveAuth))));
         authenticationRequest.setForceAuth(Boolean.parseBoolean(
                 String.valueOf(context.getParameter(InboundConstants.ForceAuth))));
+        authenticationRequest.setTenantDomain(((SAMLMessageContext) context).getTenantDomain());
         try {
             authenticationRequest.setCommonAuthCallerPath(URLEncoder.encode(getCallbackPath(context),
                     StandardCharsets.UTF_8.name()));


### PR DESCRIPTION
Tenant was not communicated to the authentication framework when delegating the request and when an authentication response was received tenant was not properly picked to get the signing key.